### PR TITLE
Uncommented bold mode

### DIFF
--- a/lib/colorize.rb
+++ b/lib/colorize.rb
@@ -32,7 +32,7 @@ class String
   #
   MODES = {
     :default        => 0, # Turn off all attributes
-    #:bright        => 1, # Set bright mode
+    :bold           => 1, # Set bold mode
     :underline      => 4, # Set underline mode
     :blink          => 5, # Set blink mode
     :swap           => 7, # Exchange foreground and background colors


### PR DESCRIPTION
Mode "1" is a bold mode. Why it was commented out?
Also, light_\* colors do not work properly with modes other that "0"
