### PR TITLE
Set the default value if #colorize is passed incorrect color value

### DIFF
--- a/lib/colorize.rb
+++ b/lib/colorize.rb
@@ -78,8 +78,8 @@ class String
         match[0] = MODES[params[:mode]] if params[:mode]
         match[1] = COLORS[params[:color]] + COLOR_OFFSET if params[:color]
         match[2] = COLORS[params[:background]] + BACKGROUND_OFFSET if params[:background]
-      elsif (params.instance_of?(Symbol))
-        match[1] = COLORS[params] +COLOR_OFFSET if params
+      elsif (params.instance_of?(Symbol)) && params
+        match[1] = (COLORS[params] || COLORS[:default]) + COLOR_OFFSET
       end
 
       str << "\033[#{match[0]};#{match[1]};#{match[2]}m#{match[3]}\033[0m"

--- a/test/test_colorize.rb
+++ b/test/test_colorize.rb
@@ -5,6 +5,10 @@ class TestColorize < Test::Unit::TestCase
     assert 'This is blue'.colorize(:blue) == "\e[0;34;49mThis is blue\e[0m"
   end
 
+  def test_incorrect_symbol
+    assert 'This is incorrect color'.colorize(:bold) == "\e[0;39;49mThis is incorrect color\e[0m"
+  end
+
   def test_blue_hash
     assert 'This is also blue'.colorize(:color => :blue) == "\e[0;34;49mThis is also blue\e[0m"
   end


### PR DESCRIPTION
Hi.
the colorize method will fail if passes incorrect color value.
I think this behavior is undesirable because it worked until releasing v0.7.0.
What do you think about this?

Thank you.
