### PR TITLE
Remove win32console gem in ruby 2.0 on windows

### DIFF
--- a/lib/colorize.rb
+++ b/lib/colorize.rb
@@ -63,7 +63,7 @@ class String
   #
   def colorize(params)
     begin
-      require 'Win32/Console/ANSI' if RUBY_PLATFORM =~ /win32/
+      require 'Win32/Console/ANSI' if RUBY_VERSION < "2.0.0" && RUBY_PLATFORM =~ /win32/
     rescue LoadError
       raise 'You must gem install win32console to use colorize on Windows'
     end


### PR DESCRIPTION
Ruby 2.0 on windows supports ANSI escape sequences, so the win32console gem is unnecessary.

https://projects.puppetlabs.com/issues/21711
