### PR TITLE
Uncolorize unbalanced color codes.

### DIFF
--- a/lib/colorize/instance_methods.rb
+++ b/lib/colorize/instance_methods.rb
@@ -31,9 +31,7 @@ module Colorize
     # Return uncolorized string
     #
     def uncolorize
-      scan_for_colors.inject('') do |str, match|
-        str << match[3]
-      end
+      gsub(/\033\[[0-9;]+m/, "")
     end
 
     #

--- a/test/test_colorize.rb
+++ b/test/test_colorize.rb
@@ -71,6 +71,11 @@ class TestColorize < Minitest::Test
                  "This is uncolorized"
   end
 
+  def test_uncolorize_unbalanced_color_codes
+    assert_equal "example", "\e[31mexample".uncolorize
+    assert_equal "example", "\e[1;31;41mexample".uncolorize
+  end
+
   def test_colorized?
     assert_equal 'Red'.red.colorized?, true
     assert_equal 'Blue'.colorized?, false


### PR DESCRIPTION
This fixes `String#uncolorize` to remove all color codes, even those without a matching `\e[0m`