### PR TITLE
Remove instance variable not initialized warning

### DIFF
--- a/lib/colorize/class_methods.rb
+++ b/lib/colorize/class_methods.rb
@@ -15,9 +15,7 @@ module Colorize
     #
     # Setter for disable colorization
     #
-    def disable_colorization=(value)
-      @disable_colorization = value
-    end
+    attr_writer :disable_colorization
 
     #
     # Return array of available colors used by colorize

--- a/lib/colorize/class_methods.rb
+++ b/lib/colorize/class_methods.rb
@@ -6,9 +6,9 @@ module Colorize
     #
     def disable_colorization(value = nil)
       if value.nil?
-        @disable_colorization || false
+        defined?(@disable_colorization) ? @disable_colorization : false
       else
-        @disable_colorization = (value || false)
+        self.disable_colorization = value
       end
     end
 
@@ -16,7 +16,7 @@ module Colorize
     # Setter for disable colorization
     #
     def disable_colorization=(value)
-      @disable_colorization = (value || false)
+      @disable_colorization = value
     end
 
     #
@@ -49,7 +49,7 @@ module Colorize
     def color_matrix(txt = '')
       fail NoMethodError, '#color_matrix method was removed, try #color_samples instead'
     end
-  
+
     # private
 
     #
@@ -82,7 +82,7 @@ module Colorize
         :hide      => 8  # Hide text (foreground color would be the same as background)
       }
     end
-    
+
     #
     # Generate color and on_color methods
     #


### PR DESCRIPTION
You can see the warning just by running tests on master. This pull checks to see if `@disable_colorization` is defined instead of relying on the instance variable's default nil value. I also made a few simplifications: 

1). If `.disable_colorization` is called with a value it just calls the setter
2) Replaces the setter with `attr_writer`. The previous logic seemed to just coerce `nil` to false. This behavior isn't tested or documented and I'm not sure what it adds.

Happy to re-open without the change to the setter if that is doing something important.