### PR TITLE
Fix gemspec files (colorized_string is broken in v0.8)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+== 0.8.1 / 2016-06-29
+  * fix gemspec bug
+
 == 0.8.0 / 2016-06-27
 	* add ColorizedString class
 	* update README file

--- a/colorize.gemspec
+++ b/colorize.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'colorize'
-  s.version = '0.8.0'
+  s.version = '0.8.1'
 
   s.authors = ['Michał Kalbarczyk']
   s.email = 'fazibear@gmail.com'
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
     'Rakefile',
     'colorize.gemspec',
     'lib/colorize.rb',
+    'lib/colorized_string.rb',
     'lib/colorize/class_methods.rb',
     'lib/colorize/instance_methods.rb',
     'test/test_colorize.rb',


### PR DESCRIPTION
Hey,

I tried to use `require 'colorized_string'` after installing `colorize-0.8.0` and it's not working. Adding it to the gemspec fixes it.