### PR TITLE
Enable support for non-strings to be colorized by implicitly converti…

### DIFF
--- a/lib/colorize.rb
+++ b/lib/colorize.rb
@@ -1,9 +1,9 @@
 require File.expand_path('colorize/class_methods', File.dirname(__FILE__))
 require File.expand_path('colorize/instance_methods', File.dirname(__FILE__))
 #
-# String class extension.
+# Object class extension.
 #
-class String
+class Object
   extend Colorize::ClassMethods
   include Colorize::InstanceMethods
 

--- a/lib/colorize/instance_methods.rb
+++ b/lib/colorize/instance_methods.rb
@@ -18,8 +18,9 @@ module Colorize
     #
     def colorize(params)
       return self if self.class.disable_colorization
+      return self.collect { |obj| obj.colorize(params) } if self.is_a?(Enumerable)
       require_windows_libs
-      scan_for_colors.inject(self.class.new) do |str, match|
+      scan_for_colors.inject("") do |str, match|
         colors_from_params(match, params)
         defaults_colors(match)
         str << "\033[#{match[0]};#{match[1]};#{match[2]}m#{match[3]}\033[0m"
@@ -30,7 +31,7 @@ module Colorize
     # Return uncolorized string
     #
     def uncolorize
-      scan_for_colors.inject(self.class.new) do |str, match|
+      scan_for_colors.inject("") do |str, match|
         str << match[3]
       end
     end
@@ -106,7 +107,7 @@ module Colorize
     # Scan for colorized string
     #
     def scan_for_colors
-      scan(/\033\[([0-9;]+)m(.+?)\033\[0m|([^\033]+)/m).map do |match|
+      to_s.scan(/\033\[([0-9;]+)m(.+?)\033\[0m|([^\033]+)/m).map do |match|
         split_colors(match)
       end
     end

--- a/test/test_colorize.rb
+++ b/test/test_colorize.rb
@@ -161,4 +161,12 @@ class TestColorize < Minitest::Test
       String.color_samples
     end
   end
+
+  def test_color_nonstring
+    assert_equal 1.blue, "\e[0;34;49m1\e[0m"
+  end
+
+  def test_color_array
+    assert_equal [1337, "NEETzsche", ["current year", Time.now], "h"].blue, ["\e[0;34;49m1337\e[0m", "\e[0;34;49mNEETzsche\e[0m", ["\e[0;34;49mcurrent year\e[0m", "\e[0;34;49m#{Time.now}\e[0m"], "\e[0;34;49mh\e[0m"]
+  end
 end


### PR DESCRIPTION
…ng them into strings first (or for enumerables, iterating over them)

I wrote this because it's annoying having to run `to_s` on everything in order to colorize a non-String, or having to iterate over every element in an Array, so it will implicitly colorize it or its elements. Just reject if you think this is a stupid or unworthwhile pursuit.