### PR TITLE
Add 'grey' and 'gray' aliases for light_black

### DIFF
--- a/lib/colorize/class_methods.rb
+++ b/lib/colorize/class_methods.rb
@@ -61,14 +61,15 @@ module Colorize
     def color_codes
       {
         :black   => 0, :light_black    => 60,
-        :red     => 1, :light_red      => 61,
-        :green   => 2, :light_green    => 62,
-        :yellow  => 3, :light_yellow   => 63,
-        :blue    => 4, :light_blue     => 64,
-        :magenta => 5, :light_magenta  => 65,
-        :cyan    => 6, :light_cyan     => 66,
-        :white   => 7, :light_white    => 67,
-        :default => 9
+        :red     => 1, :gray           => 60,
+        :green   => 2, :grey           => 60,
+        :yellow  => 3, :light_red      => 61,
+        :blue    => 4, :light_green    => 62,
+        :magenta => 5, :light_yellow   => 63,
+        :cyan    => 6, :light_blue     => 64,
+        :white   => 7, :light_magenta  => 65,
+        :default => 9, :light_cyan     => 66,
+                       :light_white    => 67,
       }
     end
 

--- a/test/test_colorize.rb
+++ b/test/test_colorize.rb
@@ -56,7 +56,7 @@ class TestColorize < Minitest::Test
                  "\e[0;31;44mThis is red on blue\e[0m"
   end
 
-  def test_red_with_blue_background_and_underline_sumbol_and_methods
+  def test_red_with_blue_background_and_underline_symbol_and_methods
     assert_equal 'This is red on blue and underline'.colorize(:red).on_blue.underline,
                  "\e[4;31;44mThis is red on blue and underline\e[0m"
   end


### PR DESCRIPTION
Thought I'd try to submit a pull request for #71. I don't know how you feel about basically adding aliases when there are existing names for things (or duplicate code in general).

## Changes

Taking a look at how the color codes are defined, it seemed like the cleanest way to suggest this was to:
* Duplicate the color code currently assigned to `:light_black`
* Re-align everything to keep it visually the way you had it before (all modes on the left, all colors on the right)
* Keep the numeric ordering the same as before (modes and colors sequential in their columns, top to bottom)

### One additional:

When taking a look at the tests I noticed:

```ruby
def test_red_with_blue_background_and_underline_sumbol_and_methods
  ...                                          # ^ small misspelling, should be the letter "y"
end
```

... so I fixed that while there.

## Tests

I read over the tests, and I don't see exhaustive tests for all colors, so if you're okay with it, I won't add a specific test for these aliases. If you wanted a test I might do something like:

```ruby
  def test_light_black_and_grey_and_gray_are_identical
    assert_equal "foo #{'bar'.light_black} #{'baz'.grey} #{'qux'.gray}",
                 "foo \e[0;90;49mbar\e[0m \e[0;90;49mbaz\e[0m \e[0;90;49mqux\e[0m"
  end
```

Here's a quick test I did in IRB to just have a look at it (with screenshot):

```ruby
irb(main):001:0> "foo #{'bar'.light_black} #{'baz'.grey} #{'qux'.gray}"
=> "foo \e[0;90;49mbar\e[0m \e[0;90;49mbaz\e[0m \e[0;90;49mqux\e[0m"
irb(main):002:0> puts "foo #{'bar'.light_black} #{'baz'.grey} #{'qux'.gray}"
foo bar baz qux
```
![Screen Shot 2022-01-06 at 11 16 09 PM](https://user-images.githubusercontent.com/618081/148495519-4f0161a1-3838-4007-8b3f-d3e74f9b9253.png)

