### PR TITLE
Add funding_uri to gemspec

### DIFF
--- a/colorize.gemspec
+++ b/colorize.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |s|
   ]
 
   s.metadata['rubygems_mfa_required'] = 'true'
+  s.metadata["funding_uri"] = "https://github.com/sponsors/fazibear"
 end


### PR DESCRIPTION
Added your github sponsors link to `funding_uri` to the gemspec to help increase visibility using the `bundle fund` command in Bundler.